### PR TITLE
fixes build failure with gcc-10

### DIFF
--- a/omx_render.h
+++ b/omx_render.h
@@ -64,7 +64,7 @@ typedef struct OMX_RENDER_DISP_CONF{
 	
 } OMX_RENDER_DISP_CONF;
 
-struct OMX_RENDER_TRANSITION{
+typedef struct OMX_RENDER_TRANSITION{
 	enum transition_t{NONE, BLEND} type;
 	int durationMs;
 	


### PR DESCRIPTION
This is a cherry-pick from the commit in the original repo to fix this issue https://github.com/HaarigerHarald/omxiv/issues/33 

which happens trying to install / update retropie_setup in an updated bullseye 